### PR TITLE
Add sitemap message

### DIFF
--- a/rmf_building_map_msgs/CMakeLists.txt
+++ b/rmf_building_map_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rosidl_default_generators REQUIRED)
 set(msg_files
   "msg/AffineImage.msg"
   "msg/BuildingMap.msg"
+  "msg/CoordinateFrame.msg"
   "msg/Door.msg"
   "msg/Graph.msg"
   "msg/GraphEdge.msg"
@@ -28,6 +29,7 @@ set(msg_files
   "msg/Lift.msg"
   "msg/Param.msg"
   "msg/Place.msg"
+  "msg/SiteMap.msg"
 )
 
 set(srv_files

--- a/rmf_building_map_msgs/msg/CoordinateFrame.msg
+++ b/rmf_building_map_msgs/msg/CoordinateFrame.msg
@@ -1,0 +1,9 @@
+# i.e. web_mercator, cartesian_meters for global units
+# reference_image for local units
+string coordinate_system
+
+# Following EPSG standard, i.e. EPSG:3414 for SVY21
+string crs_name
+
+# Offset from the coordinate frame (i.e. x,y,z for cartesian)
+float32[3] offset

--- a/rmf_building_map_msgs/msg/Frame.msg
+++ b/rmf_building_map_msgs/msg/Frame.msg
@@ -1,5 +1,0 @@
-# i.e. WGS84, cartesian_meters
-string name
-
-# Offset from the coordinate frame (i.e. x,y,z for cartesian)
-double[3] offset

--- a/rmf_building_map_msgs/msg/Frame.msg
+++ b/rmf_building_map_msgs/msg/Frame.msg
@@ -1,0 +1,5 @@
+# i.e. WGS84, cartesian_meters
+string name
+
+# Offset from the coordinate frame (i.e. x,y,z for cartesian)
+double[3] offset

--- a/rmf_building_map_msgs/msg/SiteMap.msg
+++ b/rmf_building_map_msgs/msg/SiteMap.msg
@@ -1,0 +1,4 @@
+string name
+CoordinateFrame frame
+Level[] levels
+Lift[] lifts


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR introduces a new message SiteMap, similar to BuildingMap but to be used for future development, it is meant for outdoor scenarios and currently implements all the features of BuildingMap, together with having fields to describe the coordinate reference system used in the map.
The new `CoordinateFrame` message has been designed to be easily integrated with the existing `rmf_building_map_tools` codebase

### Implementation description

Three new fields are introduced:

- `coordinate_system` follows the [CoordinateSystem](https://github.com/open-rmf/rmf_traffic_editor/blob/feature/cartesian_meters_coordinates/rmf_building_map_tools/building_map/coordinate_system.py) structure in traffic editor
- `crs_name`, also matching in [traffic_editor](https://github.com/open-rmf/rmf_traffic_editor/blob/feature/cartesian_meters_coordinates/rmf_building_map_tools/building_map/building.py#L76-L77), follows the EPSG standard.
- `offset` A tuple to specify an offset. It can be used to make the numbers more human readable in case the chosen coordinate system has a large offset.

This PR will be used by the updated building_map_server under [feature/sitemap_server](https://github.com/open-rmf/rmf_traffic_editor/blob/feature/sitemap_server/rmf_building_map_tools/building_map_server/building_map_server.py) branch in `rmf_traffic_editor`, to serve the SiteMap messages to downstream nodes.

:warning: Note! This message type is under heavy development and might not be suitable for deployment applications.