### PR TITLE
Add GraphZone, ZoneVertex, ZoneTransitionLane for GoToZone feature

### DIFF
--- a/rmf_building_map_msgs/CMakeLists.txt
+++ b/rmf_building_map_msgs/CMakeLists.txt
@@ -24,10 +24,13 @@ set(msg_files
   "msg/Graph.msg"
   "msg/GraphEdge.msg"
   "msg/GraphNode.msg"
+  "msg/GraphZone.msg"
   "msg/Level.msg"
   "msg/Lift.msg"
   "msg/Param.msg"
   "msg/Place.msg"
+  "msg/ZoneTransitionLane.msg"
+  "msg/ZoneVertex.msg"
 )
 
 set(srv_files

--- a/rmf_building_map_msgs/msg/Graph.msg
+++ b/rmf_building_map_msgs/msg/Graph.msg
@@ -1,4 +1,5 @@
 string name
 GraphNode[] vertices
 GraphEdge[] edges
+GraphZone[] zones
 Param[] params

--- a/rmf_building_map_msgs/msg/GraphZone.msg
+++ b/rmf_building_map_msgs/msg/GraphZone.msg
@@ -1,0 +1,13 @@
+string name
+string level
+string type
+
+ZoneTransitionLane[] transition_lanes
+
+float32 center_x
+float32 center_y
+float32 yaw
+float32 length
+float32 width
+
+ZoneVertex[] vertices

--- a/rmf_building_map_msgs/msg/ZoneTransitionLane.msg
+++ b/rmf_building_map_msgs/msg/ZoneTransitionLane.msg
@@ -1,0 +1,4 @@
+string internal_vertex
+string external_vertex
+bool entry_lane
+bool exit_lane

--- a/rmf_building_map_msgs/msg/ZoneVertex.msg
+++ b/rmf_building_map_msgs/msg/ZoneVertex.msg
@@ -1,0 +1,5 @@
+string name
+float32 x
+float32 y
+string group
+uint8 priority


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This is part of an 8-repo Simple GoToZone feature. Tracked in Stage A of [open-rmf/rmf#726](https://github.com/open-rmf/rmf/issues/726).

Adds three new message types and extends `Graph.msg` so the nav graph can carry zone structure: named regions containing internal waypoints, connected to the outside via transition lanes.

### Implementation description
### New messages

- **`GraphZone.msg`** — a named zone on a specific building level, with:
  - Metadata: `name`, `level`, `type` (zone category label, reserved for future zone categorisation).
  - Bounding-box geometry for visualisation: `center_x`, `center_y`, `yaw`, `length`, `width`. Used by `rmf_visualization_navgraphs` to render the zone rectangle in RViz
  - Zone lanes & internal waypoints: `ZoneVertex[] vertices` (internal waypoints inside the zone) and `ZoneTransitionLane[] transition_lanes` (the lanes that bridge internal vertices to external waypoints).
- **`ZoneVertex.msg`** — internal waypoint of a zone, with `name`, `x`, `y`, `group` (string), and `priority` (uint8). Priority lower = higher preference. Group is a label used by the zone supervisor's group-hint filter.
- **`ZoneTransitionLane.msg`** — links an `internal_vertex` (inside the zone) to an `external_vertex` (outside of zone), with two independent boolean flags: `entry_lane` and `exit_lane`. A lane may be flagged as entry or exit. The fleet adapter wires `ZoneEntry` / `ZoneExit` events on the corresponding graph lane based on these flags.

### Modified

- **`Graph.msg`** — added a `GraphZone[] zones` field so a published nav graph carries its zone metadata alongside its waypoints and lanes.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

